### PR TITLE
Fix for building with VS 43_1

### DIFF
--- a/configure
+++ b/configure
@@ -92,7 +92,7 @@ LIBNAME=""
 
 CXXFLAGS="-std=c++11 -Wall -I. -I$SRCDIR/src"
 LDFLAGS=""
-SOFLAGS="-shared -Wl,-Bsymbolic"
+SOFLAGS="-shared"
 OPTFLAGS="-D__SSE"
 TARGET="-mssse3"
 

--- a/src/vs_it_interface.h
+++ b/src/vs_it_interface.h
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA
 #include <x86intrin.h>
 #define __forceinline inline
 #define ALIGNED_ARRAY(decl, alignment) __attribute__((aligned(alignment))) decl
-#define _aligned_malloc(decl, alignment) aligned_alloc(alignment, decl)
+#define _aligned_malloc(decl, alignment) vs_aligned_malloc(alignment, decl)
 #define _aligned_free(buffer) free(buffer)
 #endif
 


### PR DESCRIPTION
This error happens when building on OS X.
Fixes [VapourSynth-IT#5](https://github.com/HomeOfVapourSynthEvolution/VapourSynth-IT/issues/5).